### PR TITLE
[JENKINS-10139] Fix for regex containing back slashes

### DIFF
--- a/src/main/java/hudson/plugins/validating_string_parameter/ValidatingStringParameterDefinition.java
+++ b/src/main/java/hudson/plugins/validating_string_parameter/ValidatingStringParameterDefinition.java
@@ -73,6 +73,10 @@ public class ValidatingStringParameterDefinition extends ParameterDefinition {
         return regex;
     }
 
+    public String getJsEncodedRegex() {
+        return regex.replace("\\", "\\\\");
+    }
+
     public String getFailedValidationMessage() {
         return failedValidationMessage;
     }

--- a/src/main/resources/hudson/plugins/validating_string_parameter/ValidatingStringParameterDefinition/index.jelly
+++ b/src/main/resources/hudson/plugins/validating_string_parameter/ValidatingStringParameterDefinition/index.jelly
@@ -29,7 +29,7 @@ THE SOFTWARE.
 		<div name="parameter" description="${it.description}">
 			<input type="hidden" name="name" value="${it.name}" />
 			<f:textbox name="value" value="${it.defaultValue}" 
-				checkUrl="'${it.rootUrl}/descriptor/hudson.plugins.validating_string_parameter.ValidatingStringParameterDefinition/validate?regex='+encodeURIComponent(&quot;${it.regex}&quot;)+'&amp;failedValidationMessage='+encodeURIComponent(&quot;${it.failedValidationMessage}&quot;)+'&amp;value='+encodeURIComponent(this.value)"/>
+				checkUrl="'${it.rootUrl}/descriptor/hudson.plugins.validating_string_parameter.ValidatingStringParameterDefinition/validate?regex='+encodeURIComponent(&quot;${it.jsEncodedRegex}&quot;)+'&amp;failedValidationMessage='+encodeURIComponent(&quot;${it.failedValidationMessage}&quot;)+'&amp;value='+encodeURIComponent(this.value)"/>
 		</div>
 	</f:entry>
 </j:jelly>


### PR DESCRIPTION
Apparently back slashes are a special char in javascript, and this would be lost when sending the regex back to the descriptor for validation. This fix adds a method that returns a javascript encoded version of the regex. This means that it will replace one back slash with two back slashes, which is the way to escape a back slash in js.

Unfortunately i dont know how to create a unit test that checks the validation in the html page; so you will have to do without one :/

It would be nice if you could merge this one, as i would like to use this plugin in our current jobs when releasing new versions of our software.

Regards
//Erik Ramfelt
