### PR TITLE
Description textarea supports HTML

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ target
 *.iws
 work
 .idea
+*.swp

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.396</version>
+    <version>1.424</version>
   </parent>
   <artifactId>validating-string-parameter</artifactId>
   <packaging>hpi</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -27,19 +27,6 @@
   	</developer>
   </developers>
   
-    <build>
-    <plugins>
-      <plugin>
-        <groupId>org.jenkins-ci.tools</groupId>
-        <artifactId>maven-hpi-plugin</artifactId>
-        <version>1.64</version>
-        <extensions>true</extensions>
-        <configuration>
-          <showDeprecation>true</showDeprecation>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
 
     <repositories>
         <repository>

--- a/src/main/resources/hudson/plugins/validating_string_parameter/ValidatingStringParameterDefinition/config.jelly
+++ b/src/main/resources/hudson/plugins/validating_string_parameter/ValidatingStringParameterDefinition/config.jelly
@@ -22,22 +22,23 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
 	xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form"
 	xmlns:i="jelly:fmt" xmlns:p="/lib/hudson/project">
     <f:entry title="${%Name}" help="/help/parameter/name.html">
-		<f:textbox field="name" />
+		<f:textbox name="parameter.name" value="${instance.name}" />
 	</f:entry>
 	<f:entry title="${%Default Value}" help="/help/parameter/string-default.html">
-		<f:textbox field="defaultValue" />
+		<f:textbox name="parameter.defaultValue" value="${instance.defaultValue}" />
 	</f:entry>
 	<f:entry title="${%Regular Expression}" help="/plugin/validating-string-parameter/help-regex.html">
-		<f:textbox field="regex"/>
+		<f:textbox name="parameter.regex" value="${instance.regex}" />
 	</f:entry>
 	<f:entry title="${%Failed Validation Message}" help="/plugin/validating-string-parameter/help-failedValidationMessage.html">
-		<f:textbox field="failedValidationMessage"/>
+		<f:textbox name="parameter.failedValidationMessage" value="${instance.failedValidationMessage}" />
 	</f:entry>
     <f:entry title="${%Description}" help="/help/parameter/description.html">
-        <f:textarea field="description" />
+        <f:textarea name="parameter.description" value="${instance.description}" codemirror-mode="${app.markupFormatter.codeMirrorMode}" codemirror-config="${app.markupFormatter.codeMirrorConfig}" previewEndpoint="/markupFormatter/previewDescription" />
     </f:entry>
 </j:jelly>

--- a/src/main/resources/hudson/plugins/validating_string_parameter/ValidatingStringParameterDefinition/config.jelly
+++ b/src/main/resources/hudson/plugins/validating_string_parameter/ValidatingStringParameterDefinition/config.jelly
@@ -27,18 +27,18 @@ THE SOFTWARE.
 	xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form"
 	xmlns:i="jelly:fmt" xmlns:p="/lib/hudson/project">
     <f:entry title="${%Name}" help="/help/parameter/name.html">
-		<f:textbox name="parameter.name" value="${instance.name}" />
+		<f:textbox field="name" />
 	</f:entry>
 	<f:entry title="${%Default Value}" help="/help/parameter/string-default.html">
-		<f:textbox name="parameter.defaultValue" value="${instance.defaultValue}" />
+		<f:textbox field="defaultValue" />
 	</f:entry>
 	<f:entry title="${%Regular Expression}" help="/plugin/validating-string-parameter/help-regex.html">
-		<f:textbox name="parameter.regex" value="${instance.regex}" />
+		<f:textbox field="regex" />
 	</f:entry>
 	<f:entry title="${%Failed Validation Message}" help="/plugin/validating-string-parameter/help-failedValidationMessage.html">
-		<f:textbox name="parameter.failedValidationMessage" value="${instance.failedValidationMessage}" />
+		<f:textbox field="failedValidationMessage" />
 	</f:entry>
     <f:entry title="${%Description}" help="/help/parameter/description.html">
-        <f:textarea name="parameter.description" value="${instance.description}" codemirror-mode="${app.markupFormatter.codeMirrorMode}" codemirror-config="${app.markupFormatter.codeMirrorConfig}" previewEndpoint="/markupFormatter/previewDescription" />
+        <f:textarea field="description" codemirror-mode="${app.markupFormatter.codeMirrorMode}" codemirror-config="${app.markupFormatter.codeMirrorConfig}" previewEndpoint="/markupFormatter/previewDescription" />
     </f:entry>
 </j:jelly>

--- a/src/main/resources/hudson/plugins/validating_string_parameter/ValidatingStringParameterDefinition/index.jelly
+++ b/src/main/resources/hudson/plugins/validating_string_parameter/ValidatingStringParameterDefinition/index.jelly
@@ -21,12 +21,12 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
-
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
 	xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form"
 	xmlns:i="jelly:fmt" xmlns:p="/lib/hudson/project">
-	<f:entry title="${it.name}" description="${it.description}">
-		<div name="parameter" description="${it.description}">
+	<f:entry title="${it.name}" description="${it.formattedDescription}">
+		<div name="parameter" description="${it.formattedDescription}">
 			<input type="hidden" name="name" value="${it.name}" />
 			<f:textbox name="value" value="${it.defaultValue}" 
 				checkUrl="'${it.rootUrl}/descriptor/hudson.plugins.validating_string_parameter.ValidatingStringParameterDefinition/validate?regex='+encodeURIComponent(&quot;${it.jsEncodedRegex}&quot;)+'&amp;failedValidationMessage='+encodeURIComponent(&quot;${it.failedValidationMessage}&quot;)+'&amp;value='+encodeURIComponent(this.value)"/>


### PR DESCRIPTION
Added support of the HTML-style description (coded copied from the Jenkins built-in StringParameterDefinition/config.jelly). Visually inspected using Jenkins 1.597.