### PR TITLE
JENKINS-23729: properly escape quotes for Javascript

### DIFF
--- a/src/main/java/hudson/plugins/validating_string_parameter/ValidatingStringParameterDefinition.java
+++ b/src/main/java/hudson/plugins/validating_string_parameter/ValidatingStringParameterDefinition.java
@@ -74,11 +74,15 @@ public class ValidatingStringParameterDefinition extends ParameterDefinition {
     }
 
     public String getJsEncodedRegex() {
-        return regex.replace("\\", "\\\\");
+        return regex.replace("\\", "\\\\").replace("\"", "\\\"");
     }
 
     public String getFailedValidationMessage() {
         return failedValidationMessage;
+    }
+
+    public String getJsFailedValidationMessage() {
+        return failedValidationMessage.replace("\\", "\\\\").replace("\"", "\\\"");
     }
 
     public String getRootUrl() {

--- a/src/main/resources/hudson/plugins/validating_string_parameter/ValidatingStringParameterDefinition/index.jelly
+++ b/src/main/resources/hudson/plugins/validating_string_parameter/ValidatingStringParameterDefinition/index.jelly
@@ -29,7 +29,7 @@ THE SOFTWARE.
 		<div name="parameter" description="${it.formattedDescription}">
 			<input type="hidden" name="name" value="${it.name}" />
 			<f:textbox name="value" value="${it.defaultValue}" 
-				checkUrl="'${it.rootUrl}/descriptor/hudson.plugins.validating_string_parameter.ValidatingStringParameterDefinition/validate?regex='+encodeURIComponent(&quot;${it.jsEncodedRegex}&quot;)+'&amp;failedValidationMessage='+encodeURIComponent(&quot;${it.failedValidationMessage}&quot;)+'&amp;value='+encodeURIComponent(this.value)"/>
+				checkUrl="'descriptorByName/hudson.plugins.validating_string_parameter.ValidatingStringParameterDefinition/validate?regex='+encodeURIComponent(&quot;${it.jsEncodedRegex}&quot;)+'&amp;failedValidationMessage='+encodeURIComponent(&quot;${it.jsFailedValidationMessage}&quot;)+'&amp;value='+encodeURIComponent(this.value)"/>
 		</div>
 	</f:entry>
 </j:jelly>


### PR DESCRIPTION
Quotes in the regexp or in the validation message need to be escaped
for Javascript as \\", otherwise the resulting checkUrl will contain
invalid Javascript, which leads to a nasty error on the Jenkins UI.

Since I also had problems with the URI as a whole, I changed it to
the descriptorByName mechanism, which works fine for us. (We're
using Jenkins 1.652)