### PR TITLE
Removed double slashes in validating_string_parameter

### DIFF
--- a/src/main/resources/hudson/plugins/validating_string_parameter/ValidatingStringParameterDefinition/index.jelly
+++ b/src/main/resources/hudson/plugins/validating_string_parameter/ValidatingStringParameterDefinition/index.jelly
@@ -29,7 +29,7 @@ THE SOFTWARE.
 		<div name="parameter" description="${it.formattedDescription}">
 			<input type="hidden" name="name" value="${it.name}" />
 			<f:textbox name="value" value="${it.defaultValue}" 
-				checkUrl="'${it.rootUrl}/descriptor/hudson.plugins.validating_string_parameter.ValidatingStringParameterDefinition/validate?regex='+encodeURIComponent(&quot;${it.jsEncodedRegex}&quot;)+'&amp;failedValidationMessage='+encodeURIComponent(&quot;${it.failedValidationMessage}&quot;)+'&amp;value='+encodeURIComponent(this.value)"/>
+				checkUrl="'${it.rootUrl}descriptor/hudson.plugins.validating_string_parameter.ValidatingStringParameterDefinition/validate?regex='+encodeURIComponent(&quot;${it.jsEncodedRegex}&quot;)+'&amp;failedValidationMessage='+encodeURIComponent(&quot;${it.failedValidationMessage}&quot;)+'&amp;value='+encodeURIComponent(this.value)"/>
 		</div>
 	</f:entry>
 </j:jelly>


### PR DESCRIPTION
I added a fix to a bug in index.jelly in order to not have double slashes invalidating_string_parameter when checking data in field. This is useful if somebody use a reverse proxy with specific security rules (like banning '//' in URLs).