### PR TITLE
Allow markup descriptions to be displayed

### DIFF
--- a/src/main/resources/hudson/plugins/validating_string_parameter/ValidatingStringParameterDefinition/index.jelly
+++ b/src/main/resources/hudson/plugins/validating_string_parameter/ValidatingStringParameterDefinition/index.jelly
@@ -25,6 +25,9 @@ THE SOFTWARE.
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
 	xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form"
 	xmlns:i="jelly:fmt" xmlns:p="/lib/hudson/project">
+	
+	<j:set var="escapeEntryTitleAndDescription" value="false"/>
+	
 	<f:entry title="${it.name}" description="${it.formattedDescription}">
 		<div name="parameter" description="${it.formattedDescription}">
 			<input type="hidden" name="name" value="${it.name}" />

--- a/src/main/resources/hudson/plugins/validating_string_parameter/ValidatingStringParameterValue/value.jelly
+++ b/src/main/resources/hudson/plugins/validating_string_parameter/ValidatingStringParameterValue/value.jelly
@@ -25,6 +25,9 @@ THE SOFTWARE.
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
 	xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form"
 	xmlns:i="jelly:fmt" xmlns:p="/lib/hudson/project">
+	
+	<j:set var="escapeEntryTitleAndDescription" value="false"/>
+	
 	<f:entry title="${it.name}" description="${it.description}">
             <div tooltip="Regular expression = ${it.regex}">
                 <f:textbox name="value" value="${it.value}" readonly="true" />


### PR DESCRIPTION
These changes allow **_html_** markup descriptions to be displayed correctly, both for:

- `ValidatingStringParameterDefinition` at _**[job name]/"Build with Parameters"**_.
- `ValidatingStringParameterValue` at _**[job name]/#[build number]/"Parameters"**_.