### PR TITLE
ValidatingStringParameterValue: Avoid an NPE if the two-argument constructor was used

### DIFF
--- a/src/main/java/hudson/plugins/validating_string_parameter/ValidatingStringParameterValue.java
+++ b/src/main/java/hudson/plugins/validating_string_parameter/ValidatingStringParameterValue.java
@@ -66,7 +66,7 @@ public class ValidatingStringParameterValue extends StringParameterValue {
 
     @Override
     public BuildWrapper createBuildWrapper(AbstractBuild<?, ?> build) {
-        if (!Pattern.matches(regex, value)) {
+        if (regex != null && !Pattern.matches(regex, value)) {
             // abort the build within BuildWrapper
             return new BuildWrapper() {
                 @Override


### PR DESCRIPTION
When (programmatically) using the two-argument constructor, `regex` is
explicitly to `null`. Guard against that when matching the `regex`.