### PR TITLE
Fix "broken" link

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
         <connection>scm:git:git://github.com/jenkinsci/validating-string-parameter-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:jenkinsci/validating-string-parameter-plugin.git
         </developerConnection>
-        <url>http://github.com/jenkinsci/validating-string-parameter-plugin</url>
+        <url>https://github.com/jenkinsci/validating-string-parameter-plugin</url>
         <tag>HEAD</tag>
     </scm>
 
@@ -68,5 +68,4 @@
         </profile>
     </profiles>
 </project>
-
 

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
         <connection>scm:git:git://github.com/jenkinsci/validating-string-parameter-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:jenkinsci/validating-string-parameter-plugin.git
         </developerConnection>
-        <url>http://github.com/jenkinsci/validating-string-parameter-pluginn</url>
+        <url>http://github.com/jenkinsci/validating-string-parameter-plugin</url>
         <tag>HEAD</tag>
     </scm>
 


### PR DESCRIPTION
Cause: typo in URL link