### PR TITLE
Fix SCM Link

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
         <connection>scm:git:git://github.com/jenkinsci/validating-string-parameter-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:jenkinsci/validating-string-parameter-plugin.git
         </developerConnection>
-        <url>http://github.com/jenkinsci/validating-string-parameter-pluginn</url>
+        <url>https://github.com/jenkinsci/validating-string-parameter-plugin</url>
         <tag>HEAD</tag>
     </scm>
 


### PR DESCRIPTION
This should fix the link in plugins.jenkins, and elsewhere it is used. Also changes link to use HTTPS. Supersedes #15 