### PR TITLE
[JENKINS-74871] Fix the broken jelly view

### DIFF
--- a/src/main/resources/hudson/plugins/validating_string_parameter/ValidatingStringParameterDefinition/index.jelly
+++ b/src/main/resources/hudson/plugins/validating_string_parameter/ValidatingStringParameterDefinition/index.jelly
@@ -32,8 +32,11 @@ THE SOFTWARE.
 	<f:invisibleEntry>
 		<f:textbox field="failedValidationMessage" value="${it.failedValidationMessage}"/>
 	</f:invisibleEntry>
-	<f:entry title="${h.xmlEscape(it.name)}" description="${it.formattedDescription}" field="defaultValue">
-		<f:textbox value="${it.defaultValue}" checkUrl="${it.descriptor.descriptorFullUrl}/validate"
-				   checkDependsOn="regex failedValidationMessage"/>
+	<f:entry title="${h.xmlEscape(it.name)}" description="${it.formattedDescription}">
+		<div name="parameter" description="${it.formattedDescription}">
+			<input type="hidden" name="name" value="${it.name}"/>
+			<f:textbox name="value" value="${it.defaultValue}" checkUrl="${it.descriptor.descriptorFullUrl}/validate"
+					   checkDependsOn="../regex ../failedValidationMessage"/>
+		</div>
 	</f:entry>
 </j:jelly>

--- a/src/test/java/hudson/plugins/validating_string_parameter/ValidatingStringParameterTest.java
+++ b/src/test/java/hudson/plugins/validating_string_parameter/ValidatingStringParameterTest.java
@@ -1,14 +1,30 @@
 package hudson.plugins.validating_string_parameter;
 
+import hudson.Functions;
+import hudson.model.FreeStyleBuild;
+import hudson.model.FreeStyleProject;
+import hudson.model.ParameterValue;
+import hudson.model.ParametersAction;
 import hudson.model.ParametersDefinitionProperty;
+import hudson.tasks.BatchFile;
+import hudson.tasks.Shell;
+import org.htmlunit.html.DomNode;
+import org.htmlunit.html.HtmlButton;
+import org.htmlunit.html.HtmlPage;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 
+import java.util.List;
+
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 
@@ -28,5 +44,31 @@ public class ValidatingStringParameterTest {
                 "])", true));
         r.buildAndAssertSuccess(p);
         assertThat(p.getProperty(ParametersDefinitionProperty.class), is(notNullValue()));
+    }
+
+    @Test
+    public void freestyle() throws Exception {
+        FreeStyleProject p = r.createProject(FreeStyleProject.class, "fs");
+        p.getBuildersList().add(Functions.isWindows() ? new BatchFile("echo test") : new Shell("echo test"));
+
+        ValidatingStringParameterDefinition def = new ValidatingStringParameterDefinition("name", "defVal", "\\w+", "Value must match the following pattern: \\w+");
+        p.addProperty(new ParametersDefinitionProperty(def));
+
+        try (JenkinsRule.WebClient wc = r.createWebClient()) {
+            wc.setThrowExceptionOnFailingStatusCode(false);
+            HtmlPage htmlPage = wc.goTo("job/fs/build");
+            HtmlButton buildButton = htmlPage.querySelector(".jenkins-button--primary");
+            buildButton.click();
+        }
+
+        r.waitUntilNoActivity();
+        List<ParameterValue> parameters = p.getLastSuccessfulBuild().getAction(ParametersAction.class).getParameters();
+        assertThat(parameters, is(not(empty())));
+        ParameterValue parameterValue = parameters.get(0);
+        assertThat(parameterValue, is(instanceOf(ValidatingStringParameterValue.class)));
+        ValidatingStringParameterValue val = (ValidatingStringParameterValue) parameterValue;
+        assertThat(val.getRegex(), is(equalTo("\\w+")));
+        assertThat(val.getValue(), is(equalTo("defVal")));
+        assertThat(val.getName(), is(equalTo("name")));
     }
 }


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
I've messed up the `index.jelly` view in https://github.com/jenkinsci/validating-string-parameter-plugin/pull/146, causing https://issues.jenkins.io/browse/JENKINS-74871.

### Testing done
Followed the steps in the JIRA ticket for manual tests. Added automated test that fails before the fix and passes after the fix.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
